### PR TITLE
Fix wayland build by removing unused winit_input_helper

### DIFF
--- a/crates/display/Cargo.toml
+++ b/crates/display/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2024"
 [dependencies]
 tracing = { workspace = true }
 winit = "0.30.11"
-winit_input_helper = "0.16.0"
 pixels = "0.15.0"
 
 yagber_app = { workspace = true }


### PR DESCRIPTION
## Summary
- drop `winit_input_helper` dependency from the `yagber_display` crate

This crate was unused and the version mismatch with `winit` caused build
issues on Wayland. Removing it resolves the build.

------
https://chatgpt.com/codex/tasks/task_e_686c02c77c1883318b22268d1e793d27